### PR TITLE
airflow_exporter: expose last start time for latest dag run

### DIFF
--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -136,6 +136,54 @@ def get_last_dagrun_info() -> List[DagStatusInfo]:
 
 
 @dataclass
+class DagRunScheduleInfo:
+    dag_id: str
+    last_start_epoch: int
+
+
+def get_last_dagrun_start_times():
+    assert(Session is not None)
+
+    dagrun_start_dates_query = (
+        Session.query(
+            DagRun.dag_id,
+            DagRun.start_date,
+            func.row_number().over(partition_by=DagRun.dag_id, order_by=DagRun.start_date.desc()).label('row_number')
+        )
+        .filter(DagRun.start_date is not None)
+        .subquery()
+    )
+
+    last_dag_run_start_dates_query = (
+        Session.query(
+            dagrun_start_dates_query.c.dag_id,
+            dagrun_start_dates_query.c.start_date,
+        )
+        .filter(dagrun_start_dates_query.c.row_number == 1)
+        .subquery()
+    )
+
+    sql_res = (
+        Session.query(
+            last_dag_run_start_dates_query.c.dag_id,
+            last_dag_run_start_dates_query.c.start_date,
+        )
+        .join(DagModel, DagModel.dag_id == last_dag_run_start_dates_query.c.dag_id)
+        .join(SerializedDagModel, SerializedDagModel.dag_id == last_dag_run_start_dates_query.c.dag_id)
+        .all()
+    )
+
+    return [
+        DagRunScheduleInfo(
+            dag_id=row.dag_id,
+            last_start_epoch=row.start_date.timestamp()
+        )
+        for row in sql_res
+    ]
+
+
+
+@dataclass
 class TaskStatusInfo:
     dag_id: str
     task_id: str
@@ -339,6 +387,28 @@ class MetricsCollector(object):
                 )
 
         yield dag_last_status_metric
+
+        last_dag_run_start_times = get_last_dagrun_start_times()
+
+        dag_last_start_timestamp_metric = GaugeMetricFamily(
+            'airflow_dag_last_start_timestamp_seconds',
+            'Last start time of a dagrun as unix epoch seconds',
+            labels=['dag_id']
+        )
+
+        for dag in last_dag_run_start_times:
+            labels = get_dag_labels(dag.dag_id)
+
+            _add_gauge_metric(
+                dag_last_start_timestamp_metric,
+                {
+                    'dag_id': dag.dag_id,
+                    **labels
+                },
+                dag.last_start_epoch
+            )
+
+        yield dag_last_start_timestamp_metric
 
         # DagRun metrics
         dag_duration_metric = GaugeMetricFamily(

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -155,10 +155,7 @@ def get_last_dagrun_start_times():
         .group_by(DagRun.dag_id)
     )
 
-    sql_res = (
-        last_dag_run_start_dates_query.all()
-    )
-
+    sql_res = last_dag_run_start_dates_query.all()
     return [
         DagRunScheduleInfo(
             dag_id=row.dag_id,


### PR DESCRIPTION
Adds a gauge metric called `airflow_dag_last_start_timestamp_seconds` which exposes latest last dag-run start time  of a DAG as UNIX epoch seconds.

As an example, for a DAG scheduled every 5 minutes, an alert could be defined as;

```promql
# Late for two runs.
(time() - airflow_dag_last_start_timestamp) / 60 > 10 
```
<img width="922" alt="image" src="https://user-images.githubusercontent.com/7118751/188125847-5e5df49a-2ffd-4cf6-9bfd-5976701038c9.png">


Query generated by SQLAlchemy for MySQL backend;
```sql
SELECT
  dag_run.dag_id AS dag_run_dag_id,
  MAX(dag_run.start_date) AS start_date
FROM
  dag_run
  INNER JOIN dag ON dag.dag_id = dag_run.dag_id
  INNER JOIN serialized_dag ON serialized_dag.dag_id = dag_run.dag_id
WHERE
  TRUE = 1
GROUP BY
  dag_run.dag_id
```